### PR TITLE
fix: Adjust assembly name rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Adjust msbuild task name
       run: |
         cd src
-        gci -r -File -Include *.cs,*.targets,*.props | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{ steps.gitversion.outputs.VersionSourceSha }}" }  | set-content $a }
+        gci -r -File -Include *.cs,*.targets,*.props,*.csproj | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{ steps.gitversion.outputs.VersionSourceSha }}" }  | set-content $a }
 
     - name: Build - CI
       run: |


### PR DESCRIPTION
Fixes this issue:

```
packages\uno.xamlmerge.task\1.1.0-dev.1\build\Uno.XamlMerge.Task.targets(19,3): 
error MSB4036: The "BatchMergeXaml_f76645703193d279913d46c9181e0642bc79c095" task was not found. 
Check the following: 
1.) The name of the task in the project file is the same as the name of the task class.
2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 
3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located 
in the "C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\amd64" directory.
```