### PR TITLE
fix: Adjust AdditionalFiles generation sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ on:
       - release/**
 
 env:
-  UnoCheck_Version: '1.2.0-dev.24'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/7017ad61795de3cb8b401282405bdbe263b77548/manifests/uno.ui-preview.manifest.json'
+  UnoCheck_Version: '1.5.4'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/34b1a60f5c1c51604b47362781969dde46979fd5/manifests/uno.ui-preview.manifest.json'
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET Core v6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100'
+        dotnet-version: '6.0.401'
 
     - name: Setup GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.9

--- a/src/UWP/TestLibrary/Generated/mergedpages01.xaml
+++ b/src/UWP/TestLibrary/Generated/mergedpages01.xaml
@@ -1,5 +1,20 @@
-<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="using:TestLibrary" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d xamarin ios android macos wasm skia" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:xamarin="http://uno.ui/xamarin" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:wasm="http://uno.ui/wasm" xmlns:macos="http://uno.ui/macos" xmlns:skia="http://uno.ui/skia" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d xamarin ios android macos wasm skia" xmlns:local="using:TestLibrary" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:xamarin="http://uno.ui/xamarin" xmlns:android="http://uno.ui/android" xmlns:ios="http://uno.ui/ios" xmlns:wasm="http://uno.ui/wasm" xmlns:macos="http://uno.ui/macos" xmlns:skia="http://uno.ui/skia" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
+    <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
     <ResourceDictionary Source="ms-appx:///TestLibrary/Colors.xaml" />
   </ResourceDictionary.MergedDictionaries>
   <ResourceDictionary.ThemeDictionaries>
@@ -12,16 +27,14 @@
       <android:FontFamily x:Key="SymbolThemeFontFamily">ms-appx:///Assets/Fonts/uno-fluentui-assets.ttf#Symbols</android:FontFamily>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
-  <!--origin: Inner1\Colors.xaml-->
+  <!--origin: Generated\mergedpages01.xaml-->
   <x:String x:Key="TestLibrary_String02">TestLibrary String 02</x:String>
-  <!--origin: Inner1\ImplicitConflict.xaml-->
   <Style x:Key="Button" TargetType="TextBlock">
     <Setter Property="FontSize" Value="12" />
   </Style>
   <Style TargetType="Button">
     <Setter Property="FontSize" Value="24" />
   </Style>
-  <!--origin: Inner1\ResourceDictionary2.xaml-->
   <xamarin:Style TargetType="ItemsControl">
     <Setter Property="Template">
       <Setter.Value>
@@ -32,7 +45,146 @@
     </Setter>
   </xamarin:Style>
   <x:String x:Key="TestLibrary_String03">TestLibrary String 02</x:String>
+  <x:String x:Key="TestLibrary_String">TestLibrary String</x:String>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
+  <!--origin: Generated\mergedpages02.xaml-->
+  <!--origin: Inner1\Colors.xaml-->
+  <!--origin: Inner1\ImplicitConflict.xaml-->
+  <!--origin: Inner1\ResourceDictionary2.xaml-->
+  <xamarin:Style TargetType="ItemsControl">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ItemsControl">
+          <ItemsPresenter Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </xamarin:Style>
   <!--origin: Inner1\_test.xaml-->
   <!--origin: ResourceDictionary1.xaml-->
-  <x:String x:Key="TestLibrary_String">TestLibrary String</x:String>
 </ResourceDictionary>

--- a/src/UWP/TestLibrary/TestLibrary.csproj
+++ b/src/UWP/TestLibrary/TestLibrary.csproj
@@ -9,7 +9,7 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="4.1.9" />
+		<PackageReference Include="Uno.UI" Version="4.6.19" />
 	</ItemGroup>
 	<ItemGroup>
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
@@ -42,8 +42,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<XamlMergeOutputFiles Include="Generated\mergedpages01.xaml"/>
-		<XamlMergeOutputFiles Include="Generated\mergedpages02.xaml"/>
+		<XamlMergeOutputFiles Include="Generated\mergedpages01.xaml" />
+		<XamlMergeOutputFiles Include="Generated\mergedpages02.xaml" />
 		<XamlMergeInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml;Themes\Generic.xaml" MergeFile="mergedpages01.xaml" />
 	</ItemGroup>
 

--- a/src/UWP/TestLibrarySingleFile/TestLibrarySingleFile.csproj
+++ b/src/UWP/TestLibrarySingleFile/TestLibrarySingleFile.csproj
@@ -9,7 +9,7 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.UI" Version="4.1.9" />
+		<PackageReference Include="Uno.UI" Version="4.6.19" />
 	</ItemGroup>
 	<ItemGroup>
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
@@ -59,11 +59,8 @@
 	  <Folder Include="Generated\" />
 	</ItemGroup>
 
-	<Target Name="AfterBuildValidation"
-			AfterTargets="AfterBuild" 
-			Condition="'$(TargetFramework)'=='uap10.0.19041'">
+	<Target Name="AfterBuildValidation" AfterTargets="AfterBuild" Condition="'$(TargetFramework)'=='uap10.0.19041'">
 		
-		<Error Condition="!exists('$(OutputPath)\$(AssemblyName)\Generated\mergedpages.xaml')"
-			   Text="Missing generated file" />
+		<Error Condition="!exists('$(OutputPath)\$(AssemblyName)\Generated\mergedpages.xaml')" Text="Missing generated file" />
 	</Target>
 </Project>

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Droid/XamlMergeUWPTest.Droid.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Droid/XamlMergeUWPTest.Droid.csproj
@@ -17,7 +17,7 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\XamlMergeUWPTest.Shared\Strings</ResourcesDirectory>

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Droid/XamlMergeUWPTest.Droid.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Droid/XamlMergeUWPTest.Droid.csproj
@@ -60,10 +60,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="4.1.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.1.9" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
+    <PackageReference Include="Uno.UI" Version="4.6.19" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Skia.Gtk/XamlMergeUWPTest.Skia.Gtk.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Skia.Gtk/XamlMergeUWPTest.Skia.Gtk.csproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.1.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.1.9" />
+    <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.6.19" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestLibrary\TestLibrary.csproj" />

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.UWP/XamlMergeUWPTest.UWP.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.UWP/XamlMergeUWPTest.UWP.csproj
@@ -11,7 +11,7 @@
       <Version>6.2.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
-    <PackageReference Include="Uno.UI" Version="4.1.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.19" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Wasm/XamlMergeUWPTest.Wasm.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.Wasm/XamlMergeUWPTest.Wasm.csproj
@@ -42,13 +42,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.1.0" />
-    <PackageReference Include="Uno.UI.WebAssembly" Version="4.1.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+    <PackageReference Include="Uno.UI.WebAssembly" Version="4.6.19" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.1.9" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.8" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TestLibrary\TestLibrary.csproj" />

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.iOS/XamlMergeUWPTest.iOS.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.iOS/XamlMergeUWPTest.iOS.csproj
@@ -113,11 +113,11 @@
     <BundleResource Include="Resources\Fonts\uno-fluentui-assets.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="4.1.9" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.1.9" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.1.9" />
+    <PackageReference Include="Uno.UI" Version="4.6.19" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.1.0" />
+    <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.iOS/XamlMergeUWPTest.iOS.csproj
+++ b/src/UWP/XamlMergeUWPTest/XamlMergeUWPTest.iOS/XamlMergeUWPTest.iOS.csproj
@@ -25,7 +25,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>portable</DebugType>
@@ -36,7 +36,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +51,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -66,7 +66,7 @@
     <MtouchUseLlvm>true</MtouchUseLlvm>
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <BuildIpa>true</BuildIpa>
-    <MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>none</DebugType>

--- a/src/Uno.XamlMerge.Task/GeneratePageList_v0.cs
+++ b/src/Uno.XamlMerge.Task/GeneratePageList_v0.cs
@@ -2,10 +2,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 
 namespace Uno.UI.Tasks.BatchMerge;
 
@@ -25,8 +22,16 @@ public class GeneratePageList_v0 : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
+        Debugger.Launch();
+
         OutputPages = MergedXamlFiles
-            .Select(f => new TaskItem(XamlMerge.Task.Utilities.FileUtilities.MakeRelative(ProjectDirectory, f.ItemSpec)))
+            .Select(f =>
+            {
+                var item = new TaskItem(XamlMerge.Task.Utilities.FileUtilities.MakeRelative(ProjectDirectory, f.ItemSpec));
+                f.CopyMetadataTo(item);
+                f.SetMetadata("XamlRuntime", "WinUI");
+                return item;
+            })
             .Except(Pages, FullPathComparer.Default)
             .Distinct(FullPathComparer.Default)
             .ToArray();

--- a/src/Uno.XamlMerge.Task/build/Uno.XamlMerge.Task.targets
+++ b/src/Uno.XamlMerge.Task/build/Uno.XamlMerge.Task.targets
@@ -8,7 +8,7 @@
 	<UsingTask TaskName="GeneratePageList_v0" AssemblyFile="$(MSBuildThisFileDirectory)..\bin\$(Configuration)_Shadow\Uno.XamlMerge.Task.v0.dll" Condition="exists('$(MSBuildThisFileDirectory)..\bin\$(Configuration)_Shadow\Uno.XamlMerge.Task.v0.dll')" />
 
 	<Target Name="GenerateMergedXaml"
-			BeforeTargets="_ComputeTargetFrameworkItems;BeforeBuild" 
+			BeforeTargets="_ComputeTargetFrameworkItems;BeforeBuild;GenerateMSBuildEditorConfigFileCore" 
 			DependsOnTargets="_XamlMergeFillProperties"
 			Condition="('$(TargetFramework)' == '' or '$(TargetFrameworks)'=='') and ('$(BuildingProject)' == 'true' or '$(DesignTimeBuild)' != 'true')">
 
@@ -22,7 +22,7 @@
 	</Target>
 
 	<Target Name="_AdjustedMergedXamlItems"
-			BeforeTargets="GetCopyToOutputDirectoryItems;BeforeBuild;BeforeCompile"
+			BeforeTargets="GetCopyToOutputDirectoryItems;BeforeBuild;BeforeCompile;GenerateMSBuildEditorConfigFileCore"
 			DependsOnTargets="_XamlMergeFillProperties">
 
 		<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.xamlmerge.task/issues/90

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that the generated xaml files are part of the additional files group generated in the editorconfig file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
